### PR TITLE
Update Gdip_All.ahk

### DIFF
--- a/Gdip_All.ahk
+++ b/Gdip_All.ahk
@@ -2926,18 +2926,18 @@ StrGetB(Address, Length:=-1, Encoding:=0)
 		; No conversion necessary, but we might not want the whole string.
 		if (Length == -1)
 			Length := DllCall("lstrlen", "UInt", Address)
-		VarSetStrCapacity(myString, Length)
+		VarSetStrCapacity(&myString, Length)
 		DllCall("lstrcpyn", "str", myString, "UInt", Address, "Int", Length + 1)
 
 	} else if (Encoding = 1200) { 	; UTF-16
 		char_count := DllCall("WideCharToMultiByte", "UInt", 0, "UInt", 0x400, "UInt", Address, "Int", Length, "UInt", 0, "UInt", 0, "UInt", 0, "UInt", 0)
-		VarSetStrCapacity(myString, char_count)
+		VarSetStrCapacity(&myString, char_count)
 		DllCall("WideCharToMultiByte", "UInt", 0, "UInt", 0x400, "UInt", Address, "Int", Length, "str", myString, "Int", char_count, "UInt", 0, "UInt", 0)
 
 	} else if IsInteger(Encoding) {
 		; Convert from target encoding to UTF-16 then to the active code page.
 		char_count := DllCall("MultiByteToWideChar", "UInt", Encoding, "UInt", 0, "UInt", Address, "Int", Length, "UInt", 0, "Int", 0)
-		VarSetStrCapacity(myString, char_count * 2)
+		VarSetStrCapacity(&myString, char_count * 2)
 		char_count := DllCall("MultiByteToWideChar", "UInt", Encoding, "UInt", 0, "UInt", Address, "Int", Length, "UInt", myString.Ptr, "Int", char_count * 2)
 		myString := StrGetB(myString.Ptr, char_count, 1200)
 	}


### PR DESCRIPTION
VarSetStrCapacity uses VarRef requiring a '&' before the first parameter.