### PR TITLE
Enable GDI+ v2

### DIFF
--- a/Gdip_All.ahk
+++ b/Gdip_All.ahk
@@ -2589,9 +2589,10 @@ Gdip_Startup()
 		throw Error("Could not load GDI+ library")
 	}
 
-	si := Buffer(A_PtrSize = 8 ? 24 : 16, 0)
-	NumPut("UInt", 1, si)
-	DllCall("gdiplus\GdiplusStartup", "UPtr*", &pToken:=0, "UPtr", si.Ptr, "UPtr", 0)
+	si := Buffer(A_PtrSize = 4 ? 20:32, 0) ; sizeof(GdiplusStartupInputEx) = 20, 32
+	NumPut("uint", 0x2, si)
+	NumPut("uint", 0x4, si, A_PtrSize = 4 ? 16:24)
+	DllCall("gdiplus\GdiplusStartup", "UPtr*", &pToken:=0, "UPtr", si, "UPtr", 0)
 	if (!pToken) {
 		throw Error("Gdiplus failed to start. Please ensure you have gdiplus on your system")
 	}


### PR DESCRIPTION
I personally reverse engineered this :)

For better compatibility with ImagePut. I don't know what would happen on older versions of Windows that don't have GDI+ v2. 

Enables the full range of image constants: https://learn.microsoft.com/en-us/windows/win32/gdiplus/-gdiplus-constant-image-file-format-constants